### PR TITLE
Update version to 1.78.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/grpc/grpc/archive/v{{ version }}.tar.gz
-    sha256: 0d631419e54ec5b29def798623ee3bf5520dac77abeab3284ef7027ec2363f91
+    sha256: e2ace790a5f2d0f83259d1390a816a33b013ea34df2e86084d927e58daa4c5d9
     patches:
       - 0001-Adjust-to-support-xla-specific-features.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.71.0" %}
+{% set version = "1.78.0" %}
 
 package:
   name: grpc-bazel-rules
@@ -24,9 +24,9 @@ test:
     - test -f ${PREFIX}/share/bazel/grpc/bazel/python_rules.bzl  # [unix]
 
 about:
-  home: https://grpc.io/
+  home: https://grpc.io
   dev_url: https://github.com/grpc/grpc
-  doc_url: https://grpc.io/docs/
+  doc_url: https://grpc.io/docs
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE


### PR DESCRIPTION
grpc-bazel-rules 1.78.0

**Destination channel:** defaults

### Links

- [PKG-13086](https://anaconda.atlassian.net/browse/PKG-13086) 
- [Upstream repository](https://github.com/grpc/grpc)

### Explanation of changes:
- New version number


[PKG-13086]: https://anaconda.atlassian.net/browse/PKG-13086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ